### PR TITLE
impl IITObjectWrapper for FileOrCDTrack

### DIFF
--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -2165,6 +2165,8 @@ com_wrapper_struct!(
     /// Safe wrapper over a [`IITFileOrCDTrack`](crate::sys::IITFileOrCDTrack)
     FileOrCDTrack);
 
+impl IITObjectWrapper for FileOrCDTrack {}
+
 impl IITTrackWrapper for FileOrCDTrack {}
 
 impl FileOrCDTrack {


### PR DESCRIPTION
Added so I can use `track.Name()` on FileOrCDTrack objects.